### PR TITLE
change doctype from html to xhtml

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype xhtml>
 <!--[if lt IE 7]><html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
 <!--[if (IE 7)&!(IEMobile)]><html class="no-js lt-ie9 lt-ie8" lang="en"><![endif]-->
 <!--[if (IE 8)&!(IEMobile)]><html class="no-js lt-ie9" lang="en"><![endif]-->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype xhtml>
 <!--[if lt IE 7]><html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
 <!--[if (IE 7)&!(IEMobile)]><html class="no-js lt-ie9 lt-ie8" lang="en"><![endif]-->
 <!--[if (IE 8)&!(IEMobile)]><html class="no-js lt-ie9" lang="en"><![endif]-->


### PR DESCRIPTION
Necessary since github updated to use a newer version of maruku, which wraps javascript in a CDATA section. This breaks if doctype is html (see https://github.com/bhollis/maruku/issues/120).
